### PR TITLE
Return JSON parsed token accounts from simulateBundle

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -1009,6 +1009,7 @@ mod tests {
                 return_data: None,
                 executed_units: 0,
                 accounts_data_len_delta: 0,
+                post_accounts: [],
             },
             programs_modified_by_tx: Box::<LoadedProgramsForTxBatch>::default(),
         }

--- a/accounts-db/src/transaction_results.rs
+++ b/accounts-db/src/transaction_results.rs
@@ -1,3 +1,5 @@
+use solana_sdk::{account::AccountSharedData, pubkey::Pubkey};
+
 use {
     crate::{
         nonce_info::{NonceFull, NonceInfo, NoncePartial},
@@ -79,6 +81,7 @@ pub struct TransactionExecutionDetails {
     /// The change in accounts data len for this transaction.
     /// NOTE: This value is valid IFF `status` is `Ok`.
     pub accounts_data_len_delta: i64,
+    pub post_accounts: Vec<(Pubkey, AccountSharedData)>,
 }
 
 #[derive(Debug, Clone)]

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -389,6 +389,7 @@ pub(crate) mod tests {
             return_data: None,
             executed_units: 0,
             accounts_data_len_delta: 0,
+            post_accounts: [],
         });
 
         let balances = TransactionBalancesSet {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4988,6 +4988,7 @@ impl Bank {
             .and_then(|info| {
                 let post_account_state_info =
                     self.get_transaction_account_state_info(&transaction_context, tx.message());
+
                 self.verify_transaction_account_state_changes(
                     &pre_account_state_info,
                     &post_account_state_info,
@@ -5042,7 +5043,7 @@ impl Bank {
         }
         let status = status.map(|_| ());
 
-        loaded_transaction.accounts = accounts;
+        loaded_transaction.accounts = accounts.clone();
         saturating_add_assign!(
             timings.details.total_account_count,
             loaded_transaction.accounts.len() as u64
@@ -5065,6 +5066,7 @@ impl Bank {
                 return_data,
                 executed_units,
                 accounts_data_len_delta,
+                post_accounts: accounts,
             },
             programs_modified_by_tx: Box::new(programs_modified_by_tx),
         }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -218,6 +218,7 @@ fn new_execution_result(
             return_data: None,
             executed_units: 0,
             accounts_data_len_delta: 0,
+            post_accounts: [],
         },
         programs_modified_by_tx: Box::<LoadedProgramsForTxBatch>::default(),
     }


### PR DESCRIPTION
#### Problem

Builds on https://github.com/jito-foundation/jito-solana/pull/559, dealing with the same issue for bundles

If you call `simulateBundle` and request JSON parsed token accounts in `preExecutionAccountsConfigs` or `postExecutionAccountsConfigs`, it will fail to parse them and you'll get base64 instead

#### Summary of Changes

- Each time we simulate a transaction in a bundle, we now store the post-simulation accounts in `TransactionExecutionDetails `
- We use this to maintain an `AccountOverrides` as we generate the bundle result in `rpc_bundle_result_from_bank_result`
- This `AccountOverrides` is passed to `get_encoded_account_inner` in the same way as we do in `simulateTransaction`, to enable encoding token accounts